### PR TITLE
Modifications to Slycot for Python 3

### DIFF
--- a/slycot/__init__.py
+++ b/slycot/__init__.py
@@ -1,7 +1,7 @@
-import examples
+import slycot.examples
 
 # Analysis routines (6/40 wrapped)
-from analysis import ab01nd,ab05md,ab05nd,ab07nd,ab08nd, ab09ad
+from slycot.analysis import ab01nd,ab05md,ab05nd,ab07nd,ab08nd, ab09ad
 
 # Data analysis routines (0/7 wrapped)
 
@@ -10,12 +10,12 @@ from analysis import ab01nd,ab05md,ab05nd,ab07nd,ab08nd, ab09ad
 # Identification routines (0/5 wrapped)
 
 # Mathematical routines (1/81 wrapped)
-from math import mc01td
+from slycot.math import mc01td
 
 # Synthesis routines (7/50 wrapped)
-from synthesis import sb01bd,sb02md,sb02mt,sb02od,sb03md,sb04md,sb04qd,sb10ad,sb10hd
+from slycot.synthesis import sb01bd,sb02md,sb02mt,sb02od,sb03md,sb04md,sb04qd,sb10ad,sb10hd
 
 # Transformation routines (6/40 wrapped)
-from transform import tb01id,tb03ad
-from transform import tc04ad,tc01od
-from transform import tf01md,tf01rd
+from slycot.transform import tb01id,tb03ad
+from slycot.transform import tc04ad,tc01od
+from slycot.transform import tf01md,tf01rd

--- a/slycot/analysis.py
+++ b/slycot/analysis.py
@@ -117,32 +117,32 @@ def ab01nd(n,m,A,B,jobz='N',tol=0,ldwork=None):
     'ncont', 'indcon', 'nblk', 'Z', 'LDZ'+hidden, 'tau', 'tol', 
     'IWORK'+hidden, 'DWORK'+hidden, 'ldwork', 'info'+hidden]
     if ldwork is None:
-	    ldwork = max(n,3*m)
+        ldwork = max(n,3*m)
     if jobz == 'N':
         out = _wrapper.ab01nd_n(n,m,A,B,tol=tol,ldwork=ldwork)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
             raise ValueError(error_text)
-		# sets Z to None
+        # sets Z to None
         out[5] = None
         return out[:-1]
-	if jobz == 'I':
-		out = _wrapper.ab01nd_i(n,m,A,B,tol=tol,ldwork=ldwork)
+    if jobz == 'I':
+        out = _wrapper.ab01nd_i(n,m,A,B,tol=tol,ldwork=ldwork)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
             e = ValueError(error_text)
             e.info = out[-1]
             raise e
         return out[:-1]
-	if jobz == 'F':
-		out = _wrapper.ab01nd_f(n,m,A,B,tol=tol,ldwork=ldwork)
+    if jobz == 'F':
+        out = _wrapper.ab01nd_f(n,m,A,B,tol=tol,ldwork=ldwork)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
             e = ValueError(error_text)
             e.info = out[-1]
             raise e
         return out[:-1]
-	raise ValueError('jobz must be either N, I or F')
+    raise ValueError('jobz must be either N, I or F')
 
 def ab05md(n1,m1,p1,n2,p2,A1,B1,C1,D1,A2,B2,C2,D2,uplo='U'):
     """ n,a,b,c,d = ab05md(n1,m1,p1,n2,p2,a1,b1,c1,d1,a2,b2,c2,d2,[uplo])
@@ -226,7 +226,7 @@ def ab05md(n1,m1,p1,n2,p2,A1,B1,C1,D1,A2,B2,C2,D2,uplo='U'):
         e.info = out[-1]
         raise e
     return out[:-1]
-	
+    
 def ab05nd(n1,m1,p1,n2,A1,B1,C1,D1,A2,B2,C2,D2,alpha=1.0,ldwork=None):
     """  n,A,B,C,D = ab05nd(n1,m1,p1,n2,A1,B1,C1,D1,A2,B2,C2,D2,[alpha,ldwork])
     
@@ -304,7 +304,7 @@ def ab05nd(n1,m1,p1,n2,A1,B1,C1,D1,A2,B2,C2,D2,alpha=1.0,ldwork=None):
         'LDC'+hidden, 'D', 'LDD'+hidden, 'IWORK'+hidden, 'DWORK'+hidden, 
         'ldwork', 'info'+hidden]
     if ldwork is None:
-	    ldwork = max(p1*p1,m1*m1,n1*p1)
+        ldwork = max(p1*p1,m1*m1,n1*p1)
     out = _wrapper.ab05nd(n1,m1,p1,n2,alpha,A1,B1,C1,D1,A2,B2,C2,D2,ldwork=ldwork)
     if out[-1] < 0:
         error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
@@ -316,7 +316,7 @@ def ab05nd(n1,m1,p1,n2,A1,B1,C1,D1,A2,B2,C2,D2,alpha=1.0,ldwork=None):
         e.info = out[-1]
         raise e
     return out[:-1]
-	
+    
 def ab07nd(n,m,A,B,C,D,ldwork=None):
     """ A_i,B_i,C_i,D_i,rcond = ab07nd(n,m,A,B,C,D,[ldwork])
     

--- a/slycot/examples.py
+++ b/slycot/examples.py
@@ -21,139 +21,139 @@ from numpy import array
 import slycot
 
 def sb02md_example():
-	A = array([ [0, 1],
-				[0, 0]])
-	Q = array([ [1, 0],
-				[0, 2]])
-	G = array([ [0, 0],
-				[0, 1]])
-	out = slycot.sb02md(2,A,G,Q,'C')
-	print '--- Example for sb02md ---'		
-	print 'The solution X is'
-	print out[0]
-	print 'rcond =', out[1]
-	
+    A = array([ [0, 1],
+                [0, 0]])
+    Q = array([ [1, 0],
+                [0, 2]])
+    G = array([ [0, 0],
+                [0, 1]])
+    out = slycot.sb02md(2,A,G,Q,'C')
+    print('--- Example for sb02md ---')      
+    print('The solution X is')
+    print(out[0])
+    print('rcond =', out[1])
+    
 def sb03md_example():
-	from numpy import zeros
-	A = array([ [3, 1, 1],
-				[1, 3, 0],
-				[0, 0, 3]])
-	C = array([ [25, 24, 15],
-				[24, 32,  8],
-				[15,  8, 40]])
-	U = zeros((3,3))
-	out = slycot.sb03md(3,C,A,U,'D')
-	print '--- Example for sb03md ---'		
-	print 'The solution X is'
-	print out[0]
-	print 'scaling factor:', out[1]
-	
+    from numpy import zeros
+    A = array([ [3, 1, 1],
+                [1, 3, 0],
+                [0, 0, 3]])
+    C = array([ [25, 24, 15],
+                [24, 32,  8],
+                [15,  8, 40]])
+    U = zeros((3,3))
+    out = slycot.sb03md(3,C,A,U,'D')
+    print('--- Example for sb03md ---')   
+    print('The solution X is')
+    print(out[0])
+    print('scaling factor:', out[1])
+    
 def ab08nd_example():
-	from numpy import zeros, size
-	from scipy.linalg import eigvals
-	A = array([ [1, 0, 0, 0, 0, 0],
-				[0, 1, 0, 0, 0, 0],
-				[0, 0, 3, 0, 0, 0],
-				[0, 0, 0,-4, 0, 0],
-				[0, 0, 0, 0,-1, 0],
-				[0, 0, 0, 0, 0, 3]])
-	B = array([ [0,-1],
-				[-1,0],
-				[1,-1],
-				[0, 0],
-				[0, 1],
-				[-1,-1]])
-	C = array([ [1, 0, 0, 1, 0, 0],
-				[0, 1, 0, 1, 0, 1],
-				[0, 0, 1, 0, 0, 1]])
-	D = zeros((3,2))
-	out = slycot.ab08nd(6,2,3,A,B,C,D)
-	nu = out[0]
-	print '--- Example for ab08nd ---'
-	print 'The finite invariant zeros are'
-	print eigvals(out[8][0:nu,0:nu],out[9][0:nu,0:nu])
-	
+    from numpy import zeros, size
+    from scipy.linalg import eigvals
+    A = array([ [1, 0, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0, 0],
+                [0, 0, 3, 0, 0, 0],
+                [0, 0, 0,-4, 0, 0],
+                [0, 0, 0, 0,-1, 0],
+                [0, 0, 0, 0, 0, 3]])
+    B = array([ [0,-1],
+                [-1,0],
+                [1,-1],
+                [0, 0],
+                [0, 1],
+                [-1,-1]])
+    C = array([ [1, 0, 0, 1, 0, 0],
+                [0, 1, 0, 1, 0, 1],
+                [0, 0, 1, 0, 0, 1]])
+    D = zeros((3,2))
+    out = slycot.ab08nd(6,2,3,A,B,C,D)
+    nu = out[0]
+    print('--- Example for ab08nd ---')
+    print('The finite invariant zeros are')
+    print(eigvals(out[8][0:nu,0:nu],out[9][0:nu,0:nu]))
+    
 def mc01td_example():
-	p = array([2, 0, 1, -1, 1])
-	out = slycot.mc01td('C',4,p)
-	print '--- Example for mc01td ...'
-	if out[1]:
-		print 'The polynomial is stable'
-	else:
-		print 'The polynomial has', out[2], 'unstable zeros'
-		
+    p = array([2, 0, 1, -1, 1])
+    out = slycot.mc01td('C',4,p)
+    print('--- Example for mc01td ...')
+    if out[1]:
+        print('The polynomial is stable')
+    else:
+        print('The polynomial has', out[2], 'unstable zeros')
+        
 def sb02od_example():
-	from numpy import zeros, shape, dot, ones
-	A = array([ [0, 1],
-				[0, 0]])
-	B = array([ [0],
-				[1]])
-	C = array([ [1, 0],
-				[0, 1],
-				[0, 0]])
-	Q = dot(C.T,C)
-	R = ones((1,1))
-	out = slycot.sb02od(2,1,A,B,Q,R,'C')
-	print '--- Example for sb01od ...'
-	print 'The solution X is'
-	print out[1]
-	print 'rcond =', out[0]
-	
+    from numpy import zeros, shape, dot, ones
+    A = array([ [0, 1],
+                [0, 0]])
+    B = array([ [0],
+                [1]])
+    C = array([ [1, 0],
+                [0, 1],
+                [0, 0]])
+    Q = dot(C.T,C)
+    R = ones((1,1))
+    out = slycot.sb02od(2,1,A,B,Q,R,'C')
+    print('--- Example for sb01od ...')
+    print('The solution X is')
+    print(out[1])
+    print('rcond =', out[0])
+    
 def tb03ad_example():
-	A = array([ [1, 2, 0],
-				[4,-1, 0],
-				[0, 0, 1]])
-	B = array([ [1, 0],
-				[0, 0],
-				[1, 0]])
-	C = array([ [0, 1,-1],
-				[0, 0, 1]])
-	D = array([ [0, 1],
-				[0, 0]])
-	n = 3
-	m = 1
-	p = 2
-	out = slycot.tb03ad(n,m,p,A,B,C,D,'R')
-	#out = slycot.tb03ad_l(n,m,p,A,B,C,D)
-	print '--- Example for tb03ad ...'
-	print 'The right polynomial representation of' 
-	print '    W(z) = C(zI-A)^-1B + D'
-	print 'is the following:' 
-	print 'index', out[4]
-	k_max = max(out[4]) + 1
-	for k in range(0,k_max):
-		print 'P_%d =' %(k)
-		print out[5][0:m,0:m,k]
-	for k in range(0,k_max):
-		print 'Q_%d =' %(k)
-		print out[6][0:m,0:p,k]
-		
+    A = array([ [1, 2, 0],
+                [4,-1, 0],
+                [0, 0, 1]])
+    B = array([ [1, 0],
+                [0, 0],
+                [1, 0]])
+    C = array([ [0, 1,-1],
+                [0, 0, 1]])
+    D = array([ [0, 1],
+                [0, 0]])
+    n = 3
+    m = 1
+    p = 2
+    out = slycot.tb03ad(n,m,p,A,B,C,D,'R')
+    #out = slycot.tb03ad_l(n,m,p,A,B,C,D)
+    print('--- Example for tb03ad ...')
+    print('The right polynomial representation of' )
+    print('    W(z) = C(zI-A)^-1B + D')
+    print('is the following:' )
+    print('index', out[4])
+    k_max = max(out[4]) + 1
+    for k in range(0,k_max):
+        print('P_%d =' %(k))
+        print(out[5][0:m,0:m,k])
+    for k in range(0,k_max):
+        print('Q_%d =' %(k))
+        print(out[6][0:m,0:p,k])
+        
 def tc04ad_example():
-	from numpy import shape,zeros
-	A = array([ [1, 2, 0],
-				[4,-1, 0],
-				[0, 0, 1]])
-	B = array([ [1, 0],
-				[0, 0],
-				[1, 0]])
-	C = array([ [0, 1,-1],
-				[0, 0, 1]])
-	D = array([ [0, 1],
-				[0, 0]])
-	n = 3
-	m = 1
-	p = 2
-	out = slycot.tb03ad(n,m,p,A,B,C,D,'R')
-	qcoeff = zeros((max(m,p),max(m,p),shape(out[6])[2]))
-	qcoeff[0:shape(out[6])[0],0:shape(out[6])[1],0:shape(out[6])[1]]
-	out2 = slycot.tc04ad(m,p,out[4],out[5][0:m,0:m,:],qcoeff,'R')
-	print '--- Example for tb04ad ...'
-	print 'The system has a state space realization (A,B,C,D) where'
-	print 'A ='
-	print out2[1]
-	print 'B ='
-	print out2[2]
-	print 'C ='
-	print out2[3]
-	print 'D ='
-	print out2[4]
+    from numpy import shape,zeros
+    A = array([ [1, 2, 0],
+                [4,-1, 0],
+                [0, 0, 1]])
+    B = array([ [1, 0],
+                [0, 0],
+                [1, 0]])
+    C = array([ [0, 1,-1],
+                [0, 0, 1]])
+    D = array([ [0, 1],
+                [0, 0]])
+    n = 3
+    m = 1
+    p = 2
+    out = slycot.tb03ad(n,m,p,A,B,C,D,'R')
+    qcoeff = zeros((max(m,p),max(m,p),shape(out[6])[2]))
+    qcoeff[0:shape(out[6])[0],0:shape(out[6])[1],0:shape(out[6])[1]]
+    out2 = slycot.tc04ad(m,p,out[4],out[5][0:m,0:m,:],qcoeff,'R')
+    print('--- Example for tb04ad ...')
+    print('The system has a state space realization (A,B,C,D) where')
+    print('A =')
+    print(out2[1])
+    print('B =')
+    print(out2[2])
+    print('C =')
+    print(out2[3])
+    print('D =')
+    print(out2[4])

--- a/slycot/synthesis.py
+++ b/slycot/synthesis.py
@@ -326,7 +326,7 @@ def sb02md(n,A,G,Q,dico,hinv='D',uplo='U',scal='N',sort='S',ldwork=None):
     'LDS'+hidden, 'U', 'LDU'+hidden, 'IWORK'+hidden, 'DWORK'+hidden, 'ldwork', 
     'BWORK'+hidden, 'INFO'+hidden]
     if ldwork is None:
-	    ldwork = max(3,6*n)
+        ldwork = max(3,6*n)
     A_inv,X,rcond,wr,wi,S,U,info = _wrapper.sb02md(dico,n,A,G,Q,hinv=hinv,uplo=uplo,scal=scal,sort=sort,ldwork=ldwork)
     if info < 0:
         error_text = "The following argument had an illegal value: "+arg_list[-info-1]
@@ -850,7 +850,7 @@ def sb03md(n,C,A,U,dico,job='X',fact='N',trana='N',ldwork=None):
         'LDU'+hidden, 'C', 'LDC'+hidden, 'scale', 'sep', 'ferr', 'wr'+hidden, 
         'wi'+hidden, 'IWORK'+hidden, 'DWORK'+hidden, 'ldwork', 'INFO'+hidden]
     if ldwork is None:
-	    ldwork = max(2*n*n,3*n)
+        ldwork = max(2*n*n,3*n)
     if dico != 'C' and dico != 'D':
         raise ValueError('dico must be either D or C')
     out = _wrapper.sb03md(dico,n,C,A,U,job=job,fact=fact,trana=trana,ldwork=ldwork)

--- a/slycot/transform.py
+++ b/slycot/transform.py
@@ -104,8 +104,8 @@ def tb01id(n,m,p,maxred,a,b,c,job='A'):
     return out[:-1]
 
 def tb03ad(n,m,p,A,B,C,D,leri,equil='N',tol=0.0,ldwork=None):
-	""" A_min,b_min,C_min,nr,index,pcoeff,qcoeff,vcoeff = tb03ad_l(n,m,p,A,B,C,D,leri,[equil,tol,ldwork])
-	
+    """ A_min,b_min,C_min,nr,index,pcoeff,qcoeff,vcoeff = tb03ad_l(n,m,p,A,B,C,D,leri,[equil,tol,ldwork])
+    
     To find a relatively prime left or right polynomial matrix representation
     with the same transfer matrix as that of a given state-space representation, 
     i.e. if leri = 'L'
@@ -203,16 +203,16 @@ def tb03ad(n,m,p,A,B,C,D,leri,equil='N',tol=0.0,ldwork=None):
             The leading porm-by-nr-by-kpcoef part of this array contains 
             the coefficients of the intermediate matrix V(s). 
             vcoeff(i,j,k) is defined as for pcoeff(i,j,k).
-	"""
-	hidden = ' (hidden by the wrapper)'
-	arg_list = ['leri', 'equil', 'n', 'm', 'P', 'A', 'LDA'+hidden, 'B', 
-	    'LDB'+hidden, 'C', 'LDC'+hidden, 'D', 'LDD'+hidden, 'nr', 'index', 
-	    'pcoeff', 'LDPCO1'+hidden, 'LDPCO2'+hidden, 'qcoeff', 'LDQCO1'+hidden, 
-	    'LDQCO2'+hidden, 'vcoeff', 'LDVCO1'+hidden, 'LDVCO2'+hidden, 'tol', 
-	    'IWORK'+hidden, 'DWORK'+hidden, 'ldwork', 'INFO'+hidden]
-	if leri == 'L':
-	    if ldwork is None:
-		    ldwork = max( 2*n + 3*max(m,p), p*(p+2))
+    """
+    hidden = ' (hidden by the wrapper)'
+    arg_list = ['leri', 'equil', 'n', 'm', 'P', 'A', 'LDA'+hidden, 'B', 
+        'LDB'+hidden, 'C', 'LDC'+hidden, 'D', 'LDD'+hidden, 'nr', 'index', 
+        'pcoeff', 'LDPCO1'+hidden, 'LDPCO2'+hidden, 'qcoeff', 'LDQCO1'+hidden, 
+        'LDQCO2'+hidden, 'vcoeff', 'LDVCO1'+hidden, 'LDVCO2'+hidden, 'tol', 
+        'IWORK'+hidden, 'DWORK'+hidden, 'ldwork', 'INFO'+hidden]
+    if leri == 'L':
+        if ldwork is None:
+            ldwork = max( 2*n + 3*max(m,p), p*(p+2))
         out = _wrapper.tb03ad_l(n,m,p,A,B,C,D,equil=equil,tol=tol,ldwork=ldwork)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
@@ -224,9 +224,9 @@ def tb03ad(n,m,p,A,B,C,D,leri,equil='N',tol=0.0,ldwork=None):
             e.info = out[-1]
             raise e
         return out[:-1]
-	if leri == 'R':
-		if ldwork is None:
-		    ldwork = max( 2*n + 3*max(m,p), m*(m+2))
+    if leri == 'R':
+        if ldwork is None:
+            ldwork = max( 2*n + 3*max(m,p), m*(m+2))
         out = _wrapper.tb03ad_r(n,m,p,A,B,C,D,equil=equil,tol=tol,ldwork=ldwork)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
@@ -238,7 +238,7 @@ def tb03ad(n,m,p,A,B,C,D,leri,equil='N',tol=0.0,ldwork=None):
             e.info = out[-1]
             raise e
         return out[:-1]
-	raise ValueError('leri must be either L or R')
+    raise ValueError('leri must be either L or R')
 
 def tc04ad(m,p,index,pcoeff,qcoeff,leri,ldwork=None):
     """ n,rcond,a,b,c,d = tc04ad_l(m,p,index,pcoeff,qcoeff,leri,[ldwork])
@@ -347,38 +347,38 @@ def tc04ad(m,p,index,pcoeff,qcoeff,leri,ldwork=None):
             e.info = out[-1]
             raise e
         return out[:-1]
-	raise ValueError('leri must be either L or R')
-	
+    raise ValueError('leri must be either L or R')
+    
 def tc01od(m,p,indlin,pcoeff,qcoeff,leri):
-	""" pcoeff,qcoeff = tc01od_l(m,p,indlim,pcoeff,qcoeff,leri)
-	
-	To find the dual right (left) polynomial matrix representation of a given 
-	left (right) polynomial matrix representation, where the right and left 
-	polynomial matrix representations are of the form Q(s)*inv(P(s)) and 
-	inv(P(s))*Q(s) respectively.
-	
-	Required arguments:
-	    m : input int
-	        The number of system inputs.  m > 0.
-	    p : input int
-	        The number of system outputs.  p > 0.
-	    indlim : input int
-	        The highest value of k for which pcoeff(.,.,k) and qcoeff(.,.,k) 
-	        are to be transposed.
+    """ pcoeff,qcoeff = tc01od_l(m,p,indlim,pcoeff,qcoeff,leri)
+    
+    To find the dual right (left) polynomial matrix representation of a given 
+    left (right) polynomial matrix representation, where the right and left 
+    polynomial matrix representations are of the form Q(s)*inv(P(s)) and 
+    inv(P(s))*Q(s) respectively.
+    
+    Required arguments:
+        m : input int
+            The number of system inputs.  m > 0.
+        p : input int
+            The number of system outputs.  p > 0.
+        indlim : input int
+            The highest value of k for which pcoeff(.,.,k) and qcoeff(.,.,k) 
+            are to be transposed.
             k = kpcoef + 1, where kpcoef is the maximum degree of the polynomials 
             in P(s).  indlim > 0.
-	    pcoeff : input rank-3 array('d') with bounds (p,p,indlim) or (m,m,indlim)
+        pcoeff : input rank-3 array('d') with bounds (p,p,indlim) or (m,m,indlim)
             If leri = 'L' then porm = p, otherwise porm = m. 
             On entry, the leading porm-by-porm-by-indlim part of this array 
             must contain the coefficients of the denominator matrix P(s).
             pcoeff(i,j,k) is the coefficient in s**(indlim-k) of polynomial 
             (i,j) of P(s), where k = 1,2,...,indlim.
-	    qcoeff : input rank-3 array('d') with bounds (max(m,p),max(m,p),indlim)
-	        On entry, the leading p-by-m-by-indlim part of this array must 
-	        contain the coefficients of the numerator matrix Q(s).
+        qcoeff : input rank-3 array('d') with bounds (max(m,p),max(m,p),indlim)
+            On entry, the leading p-by-m-by-indlim part of this array must 
+            contain the coefficients of the numerator matrix Q(s).
             qcoeff(i,j,k) is the coefficient in s**(indlim-k) of polynomial 
             (i,j) of Q(s), where k = 1,2,...,indlim.
-	    leri : input string(len=1)
+        leri : input string(len=1)
     Return objects:
         pcoeff : rank-3 array('d') with bounds (p,p,indlim)
             On exit, the leading porm-by-porm-by-indlim part of this array 
@@ -391,27 +391,27 @@ def tc01od(m,p,indlin,pcoeff,qcoeff,leri):
             = 0:  successful exit;
             < 0:  if info = -i, the i-th argument had an illegal value.
     """
-	hidden = ' (hidden by the wrapper)'
-	arg_list = ['leri', 'M', 'P', 'indlim', 'pcoeff', 'LDPCO1'+hidden, 
-	    'LDPCO2'+hidden, 'qcoeff', 'LDQCO1'+hidden, 'LDQCO2'+hidden, 
-	    'INFO'+hidden]
-	if leri == 'L':
-		out = _wrapper.tc01od_l(m,p,indlin,pcoeff,qcoeff)
+    hidden = ' (hidden by the wrapper)'
+    arg_list = ['leri', 'M', 'P', 'indlim', 'pcoeff', 'LDPCO1'+hidden, 
+        'LDPCO2'+hidden, 'qcoeff', 'LDQCO1'+hidden, 'LDQCO2'+hidden, 
+        'INFO'+hidden]
+    if leri == 'L':
+        out = _wrapper.tc01od_l(m,p,indlin,pcoeff,qcoeff)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
             e = ValueError(error_text)
             e.info = out[-1]
             raise e
         return out[:-1]
-	if leri == 'R':
-		out = _wrapper.tc01od_r(m,p,indlin,pcoeff,qcoeff)
+    if leri == 'R':
+        out = _wrapper.tc01od_r(m,p,indlin,pcoeff,qcoeff)
         if out[-1] < 0:
             error_text = "The following argument had an illegal value: "+arg_list[-out[-1]-1]
             e = ValueError(error_text)
             e.info = out[-1]
             raise e
         return out[:-1]
-	raise ValueError('leri must be either L or R')
+    raise ValueError('leri must be either L or R')
 
 def tf01md(n,m,p,N,A,B,C,D,u,x0):
     """ xf,y = tf01md(n,m,p,N,A,B,C,D,u,x0)
@@ -507,5 +507,5 @@ def tf01rd(n,m,p,N,A,B,C,ldwork=None):
         raise e
     return out[0]
 
-	
+    
 # to be replaced by python wrappers


### PR DESCRIPTION
I've made some modifications to Slycot to work with Python 3.  Specifically, import statements were updated, print statements in the examples were given parentheses, and tabs were converted to spaces (4 spaces/tab).  The tab issue popped up only under Python 3, interestingly.  These changes do not appear to affect Slycot's ability to work under Python 2.x.
